### PR TITLE
Extract GravityCamera library

### DIFF
--- a/src/GravityCamera.luau
+++ b/src/GravityCamera.luau
@@ -1,0 +1,124 @@
+--!strict
+
+local GravityCamera = {}
+GravityCamera.__index = GravityCamera
+
+function GravityCamera.new(): typeof(setmetatable({}, GravityCamera))
+	local upCFrame = CFrame.identity
+	local spinPart = workspace.Terrain :: BasePart
+
+	local self = setmetatable({
+		upCFrame = upCFrame,
+		targetUpVector = upCFrame.YVector,
+		twistCFrame = CFrame.identity,
+		spinPart = spinPart,
+		prevSpinPart = spinPart,
+		prevSpinCFrame = spinPart.CFrame,
+		transitionRate = 0.15,
+	}, GravityCamera)
+
+	return self
+end
+
+local function fromToRotation(fromUnit: Vector3, toUnit: Vector3, backupAxis: Vector3)
+	local dot, cross = fromUnit:Dot(toUnit), fromUnit:Cross(toUnit)
+	if dot < -0.99999 then
+		return CFrame.fromAxisAngle(backupAxis, math.pi)
+	end
+	return CFrame.new(0, 0, 0, cross.X, cross.Y, cross.Z, 1 + dot)
+end
+
+local function swingTwistDecomposition(inputCF: CFrame, relativeUnitAxis: Vector3)
+	local axis, theta = inputCF:ToAxisAngle()
+	local w, v = math.cos(theta / 2), math.sin(theta / 2) * axis
+
+	local proj = v:Dot(relativeUnitAxis) * relativeUnitAxis
+	local twist = CFrame.new(0, 0, 0, proj.X, proj.Y, proj.Z, w)
+
+	local swing = inputCF * twist:Inverse()
+
+	return swing, twist
+end
+
+function GravityCamera:calculateUpStep(_dt: number)
+	local axis = workspace.CurrentCamera.CFrame.RightVector
+
+	local sphericalArc = fromToRotation(self.upCFrame.YVector, self.targetUpVector, axis)
+	local transitionCF = CFrame.identity:Lerp(sphericalArc, self.transitionRate)
+
+	self.upCFrame = transitionCF * self.upCFrame
+end
+
+function GravityCamera:calculateSpinStep(_dt: number, inVehicle: boolean?)
+	local spinPart = self.spinPart
+	local prevSpinPart = self.prevSpinPart
+	local prevSpinCFrame = self.prevSpinCFrame
+
+	if inVehicle then
+		self.twistCFrame = CFrame.identity
+	elseif spinPart == prevSpinPart then
+		local rotation = spinPart.CFrame.Rotation
+		local prevRotation = prevSpinCFrame.Rotation
+
+		local delta = prevRotation:ToObjectSpace(rotation)
+		local spinAxis = delta:VectorToObjectSpace(prevRotation:VectorToObjectSpace(self.upCFrame.YVector))
+
+		local _swing, twist = swingTwistDecomposition(delta, spinAxis)
+		local deltaAxis, _deltaTheta = delta:ToAxisAngle()
+		local _twistAxis, twistTheta = twist:ToAxisAngle()
+
+		local theta = math.sign(deltaAxis:Dot(spinAxis)) * twistTheta
+		self.twistCFrame = CFrame.fromEulerAnglesYXZ(0, theta, 0)
+	end
+
+	self.prevSpinPart = spinPart
+	self.prevSpinCFrame = spinPart.CFrame
+end
+
+function GravityCamera:Step(dt: number, inVehicle: boolean?)
+	self:calculateUpStep(dt)
+	self:calculateSpinStep(dt, inVehicle)
+end
+
+function GravityCamera:GetCFrame(): CFrame
+	return self.upCFrame * self.twistCFrame
+end
+
+function GravityCamera:GetUpVector(): Vector3
+	return self.upCFrame.YVector
+end
+
+function GravityCamera:GetUpCFrame(): CFrame
+	return self.upCFrame
+end
+
+function GravityCamera:SetUpCFrame(cframe: CFrame)
+	self.upCFrame = cframe
+	self.targetUpVector = cframe.YVector
+end
+
+function GravityCamera:GetTargetUpVector(): Vector3
+	return self.targetUpVector
+end
+
+function GravityCamera:SetTargetUpVector(target: Vector3)
+	self.targetUpVector = target
+end
+
+function GravityCamera:GetSpinPart(): BasePart
+	return self.spinPart
+end
+
+function GravityCamera:SetSpinPart(part: BasePart)
+	self.spinPart = part
+end
+
+function GravityCamera:SetTransitionRate(rate: number)
+	self.transitionRate = rate
+end
+
+function GravityCamera:GetTransitionRate(): number
+	return self.transitionRate
+end
+
+return GravityCamera

--- a/src/Modifiers/GravityCamera.luau
+++ b/src/Modifiers/GravityCamera.luau
@@ -1,74 +1,16 @@
 --!strict
 
-local transitionRate: number = 0.15
-local upCFrame: CFrame = CFrame.identity
-local targetUpVector: Vector3 = upCFrame.YVector
+local GravityCamera = require(script.GravityCamera.Value) :: any
 
-local twistCFrame: CFrame = CFrame.identity
-local spinPart: BasePart = workspace.Terrain
-local prevSpinPart: BasePart = spinPart
-local prevSpinCFrame: CFrame = spinPart.CFrame
-
---
-
-local function fromToRotation(fromUnit: Vector3, toUnit: Vector3, backupAxis: Vector3)
-	local dot, cross = fromUnit:Dot(toUnit), fromUnit:Cross(toUnit)
-	if dot < -0.99999 then
-		return CFrame.fromAxisAngle(backupAxis, math.pi)
-	end
-	return CFrame.new(0, 0, 0, cross.X, cross.Y, cross.Z, 1 + dot)
-end
-
-local function swingTwistDecomposition(inputCF: CFrame, relativeUnitAxis: Vector3)
-	local axis, theta = inputCF:ToAxisAngle()
-	local w, v = math.cos(theta / 2), math.sin(theta / 2) * axis
-
-	local proj = v:Dot(relativeUnitAxis) * relativeUnitAxis
-	local twist = CFrame.new(0, 0, 0, proj.X, proj.Y, proj.Z, w)
-
-	local swing = inputCF * twist:Inverse()
-
-	return swing, twist
-end
-
-local function calculateUpStep(_dt: number)
-	local axis = workspace.CurrentCamera.CFrame.RightVector
-
-	local sphericalArc = fromToRotation(upCFrame.YVector, targetUpVector, axis)
-	local transitionCF = CFrame.identity:Lerp(sphericalArc, transitionRate)
-
-	upCFrame = transitionCF * upCFrame
-end
-
-local function calculateSpinStep(_dt: number, inVehicle: boolean)
-	if inVehicle then
-		twistCFrame = CFrame.identity
-	elseif spinPart == prevSpinPart then
-		local rotation = spinPart.CFrame - spinPart.CFrame.Position
-		local prevRotation = prevSpinCFrame - prevSpinCFrame.Position
-
-		local delta = prevRotation:ToObjectSpace(rotation)
-		local spinAxis = delta:VectorToObjectSpace(prevRotation:VectorToObjectSpace(upCFrame.YVector))
-
-		local _swing, twist = swingTwistDecomposition(delta, spinAxis)
-		local deltaAxis, _deltaTheta = delta:ToAxisAngle()
-		local _twistAxis, twistTheta = twist:ToAxisAngle()
-
-		local theta = math.sign(deltaAxis:Dot(spinAxis)) * twistTheta
-		twistCFrame = CFrame.fromEulerAnglesYXZ(0, theta, 0)
-	end
-
-	prevSpinPart = spinPart
-	prevSpinCFrame = spinPart.CFrame
-end
-
---
+local gravityCamera = GravityCamera.new()
 
 return function(PlayerModule)
 	------------
 	local cameraUtils = require(PlayerModule.CameraModule.CameraUtils) :: any
 
 	function cameraUtils.getAngleBetweenXZVectors(v1: Vector3, v2: Vector3): number
+		local upCFrame = gravityCamera:GetUpCFrame()
+
 		v1 = upCFrame:VectorToObjectSpace(v1)
 		v2 = upCFrame:VectorToObjectSpace(v2)
 
@@ -99,7 +41,7 @@ return function(PlayerModule)
 
 	function baseCamera:CalculateNewLookCFrameFromArg(suppliedLookVector: Vector3?, rotateInput: Vector2): CFrame
 		local currLookVector: Vector3 = suppliedLookVector or self:GetCameraLookVector()
-		currLookVector = upCFrame:VectorToObjectSpace(currLookVector)
+		currLookVector = gravityCamera:GetUpCFrame():VectorToObjectSpace(currLookVector)
 
 		local currPitchAngle = math.asin(currLookVector.Y)
 		local yTheta = math.clamp(rotateInput.Y, -max_y + currPitchAngle, -min_y + currPitchAngle)
@@ -117,7 +59,7 @@ return function(PlayerModule)
 	local setTransform = vehicleCameraCore.setTransform
 
 	function vehicleCameraCore:setTransform(transform: CFrame)
-		transform = upCFrame:ToObjectSpace(transform.Rotation) + transform.Position
+		transform = gravityCamera:GetUpCFrame():ToObjectSpace(transform.Rotation) + transform.Position
 		return setTransform(self, transform)
 	end
 
@@ -126,40 +68,39 @@ return function(PlayerModule)
 	local cameraInput = require(PlayerModule.CameraModule.CameraInput) :: any
 
 	function cameraObject:GetUpVector(): Vector3
-		return upCFrame.YVector
+		return gravityCamera:GetUpVector()
 	end
 
 	function cameraObject:GetUpCFrame(): CFrame
-		return upCFrame
+		return gravityCamera:GetUpCFrame()
 	end
 
 	function cameraObject:SetUpCFrame(cframe: CFrame)
-		upCFrame = cframe
-		targetUpVector = cframe.YVector
+		gravityCamera:SetUpCFrame(cframe)
 	end
 
 	function cameraObject:GetTargetUpVector(): Vector3
-		return targetUpVector
+		return gravityCamera:GetTargetUpVector()
 	end
 
 	function cameraObject:SetTargetUpVector(target: Vector3)
-		targetUpVector = target
+		gravityCamera:SetTargetUpVector(target)
 	end
 
 	function cameraObject:GetSpinPart(): BasePart
-		return spinPart
+		return gravityCamera:GetSpinPart()
 	end
 
 	function cameraObject:SetSpinPart(part: BasePart)
-		spinPart = part
+		gravityCamera:SetSpinPart(part)
 	end
 
 	function cameraObject:SetTransitionRate(rate: number)
-		transitionRate = rate
+		gravityCamera:SetTransitionRate(rate)
 	end
 
 	function cameraObject:GetTransitionRate(): number
-		return transitionRate
+		return gravityCamera:GetTransitionRate()
 	end
 
 	function cameraObject:Update(dt: number)
@@ -171,11 +112,10 @@ return function(PlayerModule)
 					and self.activeCameraController:GetMouseLockOffset()
 				or Vector3.new(0, 0, 0)
 
-			calculateUpStep(dt)
-			calculateSpinStep(dt, self:ShouldUseVehicleCamera())
+			gravityCamera:Step(dt, self:ShouldUseVehicleCamera())
 
 			local fixedCameraFocus = CFrame.new(newCameraFocus.Position) -- fixes an issue with vehicle cameras
-			local camRotation = upCFrame * twistCFrame * fixedCameraFocus:ToObjectSpace(newCameraCFrame)
+			local camRotation = gravityCamera:GetCFrame() * fixedCameraFocus:ToObjectSpace(newCameraCFrame)
 			local adjustedLockOffset = -newCameraCFrame:VectorToWorldSpace(lockOffset)
 				+ camRotation:VectorToWorldSpace(lockOffset)
 

--- a/src/init.luau
+++ b/src/init.luau
@@ -1,5 +1,17 @@
 --!strict
 
+local RunService = game:GetService("RunService")
+
+if RunService:IsClient() then
+	local GravityCamera = require(script.GravityCamera)
+
+	local module = {}
+
+	module.new = GravityCamera.new
+
+	return module
+end
+
 local Packages = script.Parent
 local PlayerModulePackage = require(Packages.PlayerModule)
 
@@ -8,6 +20,12 @@ local patched = PlayerModulePackage.getCopy(true) :: any
 local modifiers = require(patched.Modifiers) :: any
 
 -- Adjustments
+
+-- necessary so that modifiers have access after they are re-paranted
+local gravityCameraRef = Instance.new("ObjectValue")
+gravityCameraRef.Name = "GravityCamera"
+gravityCameraRef.Value = script.GravityCamera
+gravityCameraRef.Parent = script.Modifiers.GravityCamera
 
 for _, modifier in script.Modifiers:GetChildren() do
 	modifiers.add(modifier)


### PR DESCRIPTION
In order to create other gravity cameras (like my aim lock gun gravity camera) I need access to the gravity camera functionality as a library. This adds `GravityCamera.new()` for that and also separates out the gravity logic from the Roblox camera overrides.